### PR TITLE
Add HomeView with stats and game config (#10)

### DIFF
--- a/Wanderback/Models/GameMode.swift
+++ b/Wanderback/Models/GameMode.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum GameMode: String, CaseIterable, Identifiable {
+    case souvenir
+    case challenge
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .souvenir: return "Souvenir"
+        case .challenge: return "Challenge"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .souvenir: return "Ambiance détendue, sans chrono"
+        case .challenge: return "Chronomètre 30s, score dynamique"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .souvenir: return "heart.fill"
+        case .challenge: return "timer"
+        }
+    }
+}

--- a/Wanderback/Views/ContentView.swift
+++ b/Wanderback/Views/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
             } else if viewModel.notEnoughPhotos {
                 notEnoughPhotosView
             } else if viewModel.isReady {
-                HomeView()
+                HomeView(viewModel: viewModel)
             } else {
                 LoadingView(viewModel: viewModel)
             }

--- a/Wanderback/Views/HomeView.swift
+++ b/Wanderback/Views/HomeView.swift
@@ -1,12 +1,161 @@
 import SwiftUI
 
 struct HomeView: View {
-    var body: some View {
-        Text("Wanderback")
-            .font(.largeTitle)
-    }
-}
+    let viewModel: PhotoLibraryViewModel
 
-#Preview {
-    HomeView()
+    @State private var selectedMode: GameMode = .souvenir
+    @State private var selectedRounds: Int = 10
+    @FocusState private var focusedElement: HomeElement?
+
+    private let roundOptions = [5, 10, 20]
+
+    enum HomeElement: Hashable {
+        case mode(GameMode)
+        case rounds(Int)
+        case play
+    }
+
+    var body: some View {
+        VStack(spacing: 50) {
+            // Header
+            header
+
+            // Stats
+            statsRow
+
+            // Mode selection
+            modeSelection
+
+            // Rounds selection
+            roundsSelection
+
+            // Play button
+            playButton
+        }
+        .padding(80)
+        .defaultFocus($focusedElement, .play)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Text("Wanderback")
+                .font(.system(size: 60, weight: .bold))
+            Text("Devinez où ont été prises vos photos")
+                .font(.system(size: 28))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Stats
+
+    private var statsRow: some View {
+        HStack(spacing: 60) {
+            statItem(
+                icon: "photo.fill",
+                value: "\(viewModel.photoLocations.count)",
+                label: "photos GPS"
+            )
+            statItem(
+                icon: "mappin.and.ellipse",
+                value: "\(viewModel.clusterCount)",
+                label: "lieux"
+            )
+            statItem(
+                icon: "flag.fill",
+                value: "\(viewModel.countryCount)",
+                label: "pays"
+            )
+        }
+    }
+
+    private func statItem(icon: String, value: String, label: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 32))
+                .foregroundStyle(.blue)
+            Text(value)
+                .font(.system(size: 40, weight: .bold))
+            Text(label)
+                .font(.system(size: 22))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Mode Selection
+
+    private var modeSelection: some View {
+        VStack(spacing: 16) {
+            Text("Mode de jeu")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 30) {
+                ForEach(GameMode.allCases) { mode in
+                    Button {
+                        selectedMode = mode
+                    } label: {
+                        HStack(spacing: 16) {
+                            Image(systemName: mode.icon)
+                                .font(.system(size: 28))
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(mode.title)
+                                    .font(.system(size: 28, weight: .semibold))
+                                Text(mode.subtitle)
+                                    .font(.system(size: 20))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.horizontal, 30)
+                        .padding(.vertical, 20)
+                    }
+                    .focused($focusedElement, equals: .mode(mode))
+                    .opacity(selectedMode == mode ? 1.0 : 0.5)
+                }
+            }
+        }
+    }
+
+    // MARK: - Rounds Selection
+
+    private var roundsSelection: some View {
+        VStack(spacing: 16) {
+            Text("Nombre de rounds")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 30) {
+                ForEach(roundOptions, id: \.self) { count in
+                    Button {
+                        selectedRounds = count
+                    } label: {
+                        Text("\(count)")
+                            .font(.system(size: 36, weight: .bold))
+                            .frame(width: 120, height: 80)
+                    }
+                    .focused($focusedElement, equals: .rounds(count))
+                    .opacity(selectedRounds == count ? 1.0 : 0.5)
+                }
+            }
+        }
+    }
+
+    // MARK: - Play Button
+
+    private var playButton: some View {
+        Button {
+            // TODO: Navigation vers GameView (issue #8)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 28))
+                Text("Jouer")
+                    .font(.system(size: 32, weight: .bold))
+            }
+            .padding(.horizontal, 60)
+            .padding(.vertical, 20)
+        }
+        .focused($focusedElement, equals: .play)
+    }
 }


### PR DESCRIPTION
## Summary

- **HomeView** : écran d'accueil avec branding, stats bibliothèque (photos GPS, lieux, pays), choix du mode (Souvenir/Challenge), sélection du nombre de rounds (5/10/20), bouton Jouer
- **GameMode enum** : modèle pour les deux modes de jeu avec titre, description et icône
- **Focus tvOS** : `@FocusState` pour la navigation Siri Remote, focus par défaut sur le bouton Jouer
- **ContentView** : passe le ViewModel à HomeView pour afficher les stats

## Test plan

- [ ] Vérifier que HomeView s'affiche après le chargement
- [ ] Stats (photos, lieux, pays) correspondent aux données indexées
- [ ] Navigation focus fonctionne entre modes, rounds et bouton Jouer
- [ ] Sélection mode/rounds change visuellement (opacité)
- [ ] Build tvOS réussi

🤖 Generated with [Claude Code](https://claude.com/claude-code)