### PR TITLE
Refonte UI game-show des 6 écrans tvOS (handoff design)

### DIFF
--- a/Wanderback/DesignSystem/Theme.swift
+++ b/Wanderback/DesignSystem/Theme.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+/// Tokens du design system Wanderback (handoff « game-show » indigo / ambre→rose).
+/// Mesures définies sur canvas 1920×1080 (tvOS standard).
+enum Theme {
+    // MARK: - Couleurs
+
+    /// Haut du fond de scène
+    static let backgroundTop = Color(hex: 0x232048)
+    /// Bas du fond de scène
+    static let backgroundBottom = Color(hex: 0x131226)
+    /// Accent ambre (chrono, score, dégradés)
+    static let amber = Color(hex: 0xE3A44F)
+    /// Accent rose (toujours pairé avec l'ambre)
+    static let rose = Color(hex: 0xE88BC4)
+    /// Badge bonne réponse
+    static let success = Color(hex: 0x4CC98A)
+    /// Badge mauvaise réponse, pins de carte
+    static let error = Color(hex: 0xE86A5A)
+    /// Texte sombre sur fond clair (focus, CTA)
+    static let inkDark = Color(hex: 0x131226)
+
+    static let textSecondary = Color.white.opacity(0.7)
+    static let textTertiary = Color.white.opacity(0.45)
+
+    /// Surface des cartes réponse
+    static let answerSurface = Color(red: 22 / 255, green: 20 / 255, blue: 42 / 255).opacity(0.78)
+    static let answerBorder = Color.white.opacity(0.14)
+
+    // MARK: - Dégradés
+
+    /// Dégradé signature ambre → rose (90°)
+    static let signatureGradient = LinearGradient(
+        colors: [amber, rose],
+        startPoint: .leading,
+        endPoint: .trailing
+    )
+
+    /// Tuile mode Souvenir : violet-rose sombre, 160°
+    static let souvenirTileGradient = LinearGradient(
+        colors: [Color(hex: 0x8A4A78), Color(hex: 0x5A3050)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    /// Tuile mode Challenge : ambre sombre, 160°
+    static let challengeTileGradient = LinearGradient(
+        colors: [Color(hex: 0x9A6B2A), Color(hex: 0x63451B)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    // MARK: - Ombres
+
+    static let focusShadow = Color.black.opacity(0.6)
+    static let tileShadow = Color.black.opacity(0.45)
+    static let ctaHalo = rose.opacity(0.4)
+
+    /// Durée standard des transitions de focus (180 ms)
+    static let focusAnimation = Animation.easeOut(duration: 0.18)
+}
+
+extension Color {
+    init(hex: UInt32) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - Fond de scène
+
+/// Fond radial commun à tous les écrans : #232048 (haut) vers #131226.
+struct SceneBackground: View {
+    var body: some View {
+        RadialGradient(
+            colors: [Theme.backgroundTop, Theme.backgroundBottom],
+            center: .init(x: 0.5, y: 0.25),
+            startRadius: 0,
+            endRadius: 1400
+        )
+        .ignoresSafeArea()
+    }
+}
+
+// MARK: - Styles de boutons
+
+/// Pilule dégradé signature (CTA « C'EST PARTI », « Round suivant », « Rejouer »).
+struct GradientPillButtonStyle: ButtonStyle {
+    var horizontalPadding: CGFloat = 104
+    var verticalPadding: CGFloat = 24
+    var fontSize: CGFloat = 32
+
+    func makeBody(configuration: Configuration) -> some View {
+        GradientPillLabel(
+            configuration: configuration,
+            horizontalPadding: horizontalPadding,
+            verticalPadding: verticalPadding,
+            fontSize: fontSize
+        )
+    }
+
+    private struct GradientPillLabel: View {
+        @Environment(\.isFocused) private var isFocused
+        let configuration: ButtonStyle.Configuration
+        let horizontalPadding: CGFloat
+        let verticalPadding: CGFloat
+        let fontSize: CGFloat
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: fontSize, weight: .heavy))
+                .foregroundStyle(Theme.inkDark)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .background(Theme.signatureGradient, in: Capsule())
+                .shadow(
+                    color: isFocused ? Theme.ctaHalo : Theme.ctaHalo.opacity(0.5),
+                    radius: 25, y: 20
+                )
+                .scaleEffect(isFocused ? 1.08 : 1.0)
+                .animation(Theme.focusAnimation, value: isFocused)
+        }
+    }
+}
+
+/// Pilule secondaire translucide (« Changer de mode », « Voir comment faire »).
+struct SecondaryPillButtonStyle: ButtonStyle {
+    var horizontalPadding: CGFloat = 60
+    var verticalPadding: CGFloat = 22
+    var fontSize: CGFloat = 26
+
+    func makeBody(configuration: Configuration) -> some View {
+        SecondaryPillLabel(
+            configuration: configuration,
+            horizontalPadding: horizontalPadding,
+            verticalPadding: verticalPadding,
+            fontSize: fontSize
+        )
+    }
+
+    private struct SecondaryPillLabel: View {
+        @Environment(\.isFocused) private var isFocused
+        let configuration: ButtonStyle.Configuration
+        let horizontalPadding: CGFloat
+        let verticalPadding: CGFloat
+        let fontSize: CGFloat
+
+        var body: some View {
+            configuration.label
+                .font(.system(size: fontSize, weight: .bold))
+                .foregroundStyle(isFocused ? Theme.inkDark : .white)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .background(
+                    isFocused ? Color.white : Color.white.opacity(0.1),
+                    in: Capsule()
+                )
+                .overlay(
+                    Capsule().strokeBorder(Color.white.opacity(isFocused ? 0 : 0.2), lineWidth: 3)
+                )
+                .shadow(color: isFocused ? Theme.focusShadow : .clear, radius: 25, y: 20)
+                .scaleEffect(isFocused ? 1.08 : 1.0)
+                .animation(Theme.focusAnimation, value: isFocused)
+        }
+    }
+}
+
+/// Texte avec le dégradé signature en masque (logo, score final).
+struct GradientText: View {
+    let text: String
+    let size: CGFloat
+    var weight: Font.Weight = .heavy
+    var tracking: CGFloat = 0
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: size, weight: weight))
+            .tracking(tracking)
+            .foregroundStyle(Theme.signatureGradient)
+    }
+}

--- a/Wanderback/Models/DemoData.swift
+++ b/Wanderback/Models/DemoData.swift
@@ -1,0 +1,52 @@
+import Foundation
+import CoreLocation
+
+/// Destinations fictives pour le mode démo (écran « Pas assez de destinations »).
+/// Les photos n'ont pas d'asset PhotoKit : le jeu affiche alors un dégradé de simulation.
+enum DemoData {
+    static let clusters: [LocationCluster] = [
+        makeCluster("Paris", "France", 48.8566, 2.3522, photoCount: 4, year: 2023, month: 5),
+        makeCluster("Lisbonne", "Portugal", 38.7223, -9.1393, photoCount: 5, year: 2022, month: 7),
+        makeCluster("Séville", "Espagne", 37.3891, -5.9845, photoCount: 3, year: 2023, month: 9),
+        makeCluster("Rome", "Italie", 41.9028, 12.4964, photoCount: 4, year: 2021, month: 6),
+        makeCluster("Tokyo", "Japon", 35.6762, 139.6503, photoCount: 6, year: 2024, month: 4),
+        makeCluster("New York", "États-Unis", 40.7128, -74.0060, photoCount: 3, year: 2022, month: 11),
+        makeCluster("Marrakech", "Maroc", 31.6295, -7.9811, photoCount: 4, year: 2023, month: 3),
+        makeCluster("Reykjavik", "Islande", 64.1466, -21.9426, photoCount: 3, year: 2024, month: 8)
+    ]
+
+    private static func makeCluster(
+        _ name: String,
+        _ country: String,
+        _ latitude: Double,
+        _ longitude: Double,
+        photoCount: Int,
+        year: Int,
+        month: Int
+    ) -> LocationCluster {
+        let center = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        let baseDate = Calendar.current.date(
+            from: DateComponents(year: year, month: month, day: 14, hour: 15)
+        ) ?? .now
+
+        let photos = (0..<photoCount).map { index in
+            PhotoLocation(
+                id: "demo-\(name)-\(index)",
+                coordinate: CLLocationCoordinate2D(
+                    latitude: latitude + Double(index) * 0.002,
+                    longitude: longitude + Double(index) * 0.002
+                ),
+                dateTaken: baseDate.addingTimeInterval(TimeInterval(index) * 3600),
+                assetIdentifier: ""
+            )
+        }
+
+        return LocationCluster(
+            id: UUID(),
+            centerCoordinate: center,
+            photos: photos,
+            displayName: name,
+            country: country
+        )
+    }
+}

--- a/Wanderback/Models/GameMode.swift
+++ b/Wanderback/Models/GameMode.swift
@@ -15,8 +15,8 @@ enum GameMode: String, CaseIterable, Identifiable {
 
     var subtitle: String {
         switch self {
-        case .souvenir: return "Ambiance détendue, sans chrono"
-        case .challenge: return "Chronomètre 30s, score dynamique"
+        case .souvenir: return "Tranquille, on se remémore ensemble"
+        case .challenge: return "30 s, 1000 pts, qui gagne ?"
         }
     }
 

--- a/Wanderback/Services/PhotoImageLoader.swift
+++ b/Wanderback/Services/PhotoImageLoader.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Photos
+import UIKit
+
+/// Charge les images PhotoKit (photo de round plein écran, mosaïque d'accueil, vignettes).
+@MainActor
+final class PhotoImageLoader {
+    static let shared = PhotoImageLoader()
+
+    private let cachingManager = PHCachingImageManager()
+
+    private init() {}
+
+    /// Charge l'image d'un asset par son identifiant local. Retourne nil si introuvable
+    /// (cas du mode démo, où les rounds n'ont pas de vraie photo).
+    func loadImage(assetIdentifier: String, targetSize: CGSize) async -> UIImage? {
+        guard !assetIdentifier.isEmpty else { return nil }
+        let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [assetIdentifier], options: nil)
+        guard let asset = fetchResult.firstObject else { return nil }
+        return await requestImage(for: asset, targetSize: targetSize)
+    }
+
+    /// Sélectionne `count` photos au hasard dans la bibliothèque pour la mosaïque d'accueil.
+    func loadRandomImages(from locations: [PhotoLocation], count: Int, targetSize: CGSize) async -> [UIImage] {
+        let picked = locations.shuffled().prefix(count)
+        var images: [UIImage] = []
+        for location in picked {
+            if let image = await loadImage(assetIdentifier: location.assetIdentifier, targetSize: targetSize) {
+                images.append(image)
+            }
+        }
+        return images
+    }
+
+    private func requestImage(for asset: PHAsset, targetSize: CGSize) async -> UIImage? {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = true
+        options.resizeMode = .fast
+
+        return await withCheckedContinuation { continuation in
+            var didResume = false
+            cachingManager.requestImage(
+                for: asset,
+                targetSize: targetSize,
+                contentMode: .aspectFill,
+                options: options
+            ) { image, info in
+                // Avec deliveryMode .highQualityFormat le callback n'est appelé qu'une fois,
+                // sauf annulation/erreur — on se protège d'un double resume.
+                guard !didResume else { return }
+                didResume = true
+                continuation.resume(returning: image)
+            }
+        }
+    }
+}

--- a/Wanderback/ViewModels/GameViewModel.swift
+++ b/Wanderback/ViewModels/GameViewModel.swift
@@ -1,7 +1,189 @@
 import Foundation
+import CoreLocation
+import os
 
+@MainActor
 @Observable
 class GameViewModel {
-    var session: GameSession?
-    var isLoadingRound = false
+    enum Phase {
+        case playing
+        case revealing
+        case finished
+    }
+
+    /// Durée d'un round en mode Challenge (secondes)
+    static let roundDuration: TimeInterval = 30
+    /// Points max par round en mode Challenge, dégressifs selon le temps
+    static let maxPointsPerRound = 1000
+
+    private(set) var session: GameSession?
+    private(set) var mode: GameMode = .souvenir
+    private(set) var phase: Phase = .playing
+    private(set) var score = 0
+    private(set) var timerRemaining: TimeInterval = GameViewModel.roundDuration
+    /// Points gagnés sur le round qui vient d'être joué (affichés sur RevealView)
+    private(set) var lastPointsEarned = 0
+
+    private var clusters: [LocationCluster] = []
+    private let questionGenerator = QuestionGenerator()
+    private var timerTask: Task<Void, Never>?
+    private let logger = Logger(subsystem: "com.bastien.Wanderback", category: "GameViewModel")
+
+    /// Cluster « chez vous » : celui qui contient le plus de photos.
+    private var homeCluster: LocationCluster? {
+        clusters.max { $0.photoCount < $1.photoCount }
+    }
+
+    var currentRound: GameRound? { session?.currentRound }
+
+    var roundLabel: String {
+        guard let session else { return "" }
+        return "Round \(min(session.currentRoundIndex + 1, session.rounds.count))/\(session.rounds.count)"
+    }
+
+    var isLastRound: Bool {
+        guard let session else { return true }
+        return session.currentRoundIndex >= session.rounds.count - 1
+    }
+
+    var correctAnswersCount: Int {
+        session?.rounds.filter { $0.isCorrect == true }.count ?? 0
+    }
+
+    var answeredRoundsCount: Int {
+        session?.rounds.filter { $0.playerAnswer != nil || $0.timeElapsed != nil }.count ?? 0
+    }
+
+    /// Distance cumulée entre les lieux joués, en km (« 6 240 km parcourus »)
+    var totalDistanceKm: Int {
+        guard let rounds = session?.rounds, rounds.count > 1 else { return 0 }
+        var total: CLLocationDistance = 0
+        for (previous, next) in zip(rounds, rounds.dropFirst()) {
+            total += previous.correctAnswer.distance(to: next.correctAnswer)
+        }
+        return Int(total / 1000)
+    }
+
+    var countriesVisitedCount: Int {
+        guard let rounds = session?.rounds else { return 0 }
+        return Set(rounds.map { $0.correctAnswer.country }).subtracting([""]).count
+    }
+
+    /// Distance entre le lieu du round courant et « chez vous », en km. Nil si trop proche.
+    var distanceFromHomeKm: Int? {
+        guard let round = currentRound, let home = homeCluster else { return nil }
+        let km = Int(home.distance(to: round.correctAnswer) / 1000)
+        return km >= 50 ? km : nil
+    }
+
+    // MARK: - Cycle de vie de la partie
+
+    func startGame(mode: GameMode, roundCount: Int, clusters: [LocationCluster]) {
+        self.mode = mode
+        self.clusters = clusters
+        questionGenerator.reset()
+
+        var rounds: [GameRound] = []
+        for _ in 0..<roundCount {
+            guard let round = questionGenerator.generateRound(from: clusters) else { break }
+            rounds.append(round)
+        }
+        guard !rounds.isEmpty else {
+            logger.error("Could not generate any round")
+            return
+        }
+        if rounds.count < roundCount {
+            logger.info("Only \(rounds.count)/\(roundCount) rounds generated")
+        }
+
+        session = GameSession(id: UUID(), startDate: .now, rounds: rounds, currentRoundIndex: 0)
+        score = 0
+        lastPointsEarned = 0
+        phase = .playing
+        startTimerIfNeeded()
+    }
+
+    func answer(_ cluster: LocationCluster) {
+        guard phase == .playing, let session, let round = session.currentRound else { return }
+        stopTimer()
+
+        let elapsed = Self.roundDuration - timerRemaining
+        let isCorrect = cluster.id == round.correctAnswer.id
+
+        var updatedRound = round
+        updatedRound.playerAnswer = cluster
+        updatedRound.timeElapsed = elapsed
+        self.session?.rounds[session.currentRoundIndex] = updatedRound
+
+        if mode == .challenge {
+            lastPointsEarned = isCorrect ? pointsForRemainingTime(timerRemaining) : 0
+            score += lastPointsEarned
+        }
+        phase = .revealing
+    }
+
+    /// Temps écoulé en mode Challenge : compte comme une mauvaise réponse.
+    private func timeOut() {
+        guard phase == .playing, let session, let round = session.currentRound else { return }
+        stopTimer()
+
+        var updatedRound = round
+        updatedRound.timeElapsed = Self.roundDuration
+        self.session?.rounds[session.currentRoundIndex] = updatedRound
+
+        lastPointsEarned = 0
+        phase = .revealing
+    }
+
+    func nextRound() {
+        guard let session else { return }
+        let nextIndex = session.currentRoundIndex + 1
+        self.session?.currentRoundIndex = nextIndex
+
+        if nextIndex >= session.rounds.count {
+            phase = .finished
+        } else {
+            phase = .playing
+            startTimerIfNeeded()
+        }
+    }
+
+    func replay() {
+        guard let session else { return }
+        startGame(mode: mode, roundCount: session.rounds.count, clusters: clusters)
+    }
+
+    func quit() {
+        stopTimer()
+        session = nil
+        phase = .playing
+    }
+
+    // MARK: - Chrono (mode Challenge)
+
+    private func startTimerIfNeeded() {
+        timerRemaining = Self.roundDuration
+        guard mode == .challenge else { return }
+
+        timerTask = Task { [weak self] in
+            while let self, !Task.isCancelled, self.timerRemaining > 0 {
+                try? await Task.sleep(for: .milliseconds(100))
+                guard !Task.isCancelled else { return }
+                self.timerRemaining = max(0, self.timerRemaining - 0.1)
+            }
+            self?.timeOut()
+        }
+    }
+
+    private func stopTimer() {
+        timerTask?.cancel()
+        timerTask = nil
+    }
+
+    /// 1000 pts dégressifs selon le temps restant, arrondis à la dizaine.
+    private func pointsForRemainingTime(_ remaining: TimeInterval) -> Int {
+        let ratio = max(0, min(1, remaining / Self.roundDuration))
+        let raw = Double(Self.maxPointsPerRound) * ratio
+        return max(10, Int((raw / 10).rounded()) * 10)
+    }
 }

--- a/Wanderback/ViewModels/PhotoLibraryViewModel.swift
+++ b/Wanderback/ViewModels/PhotoLibraryViewModel.swift
@@ -67,11 +67,39 @@ class PhotoLibraryViewModel {
 
     var clusterCount: Int { clusters.count }
 
+    /// Bascule en mode démo avec des destinations fictives (écran « Pas assez de destinations »).
+    func startDemoMode() {
+        clusters = DemoData.clusters
+        photoLocations = clusters.flatMap(\.photos)
+        totalPhotoCount = photoLocations.count
+        notEnoughPhotos = false
+        errorMessage = nil
+        currentStep = .ready
+        logger.info("Demo mode started with \(self.clusters.count) fake clusters")
+    }
+
     var countryCount: Int {
         Set(clusters.map(\.country)).subtracting([""]).count
     }
 
     func requestAccessAndLoadPhotos(modelContext: ModelContext) async {
+        // Lancement direct en mode démo (dev / démonstration sans bibliothèque photo)
+        if ProcessInfo.processInfo.arguments.contains("-demoMode") {
+            startDemoMode()
+            return
+        }
+
+        #if DEBUG
+        // Dev uniquement : fige l'écran de chargement pour vérification visuelle
+        if let flagIndex = ProcessInfo.processInfo.arguments.firstIndex(of: "-screen"),
+           ProcessInfo.processInfo.arguments.dropFirst(flagIndex + 1).first == "loading" {
+            totalPhotoCount = 1247
+            photoLocations = DemoData.clusters.flatMap(\.photos)
+            currentStep = .geocoding(current: 14, total: 23)
+            return
+        }
+        #endif
+
         isLoading = true
         defer { isLoading = false }
 

--- a/Wanderback/ViewModels/RevealViewModel.swift
+++ b/Wanderback/ViewModels/RevealViewModel.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-@Observable
-class RevealViewModel {
-    var currentRound: GameRound?
-    var showMap = false
-}

--- a/Wanderback/Views/AnswerOptionsView.swift
+++ b/Wanderback/Views/AnswerOptionsView.swift
@@ -1,11 +1,68 @@
 import SwiftUI
 
+/// Grille 4 colonnes de cartes réponse (ville + pays).
 struct AnswerOptionsView: View {
+    let options: [LocationCluster]
+    let onSelect: (LocationCluster) -> Void
+
+    @FocusState private var focusedOption: UUID?
+
     var body: some View {
-        Text("Answer Options")
+        HStack(spacing: 24) {
+            ForEach(options) { option in
+                Button {
+                    onSelect(option)
+                } label: {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(option.displayName)
+                            .font(.system(size: 28, weight: .heavy))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                        Text(option.country)
+                            .font(.system(size: 21))
+                            .opacity(0.6)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 24)
+                }
+                .buttonStyle(AnswerCardButtonStyle())
+                .focused($focusedOption, equals: option.id)
+            }
+        }
     }
 }
 
-#Preview {
-    AnswerOptionsView()
+/// Carte réponse : surface sombre + blur, bordure 3pt ; focus = fond blanc, texte sombre, scale 1.07.
+private struct AnswerCardButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        AnswerCardLabel(configuration: configuration)
+    }
+
+    private struct AnswerCardLabel: View {
+        @Environment(\.isFocused) private var isFocused
+        let configuration: ButtonStyle.Configuration
+
+        var body: some View {
+            configuration.label
+                .foregroundStyle(isFocused ? Theme.inkDark : .white)
+                .background {
+                    if isFocused {
+                        RoundedRectangle(cornerRadius: 20).fill(Color.white)
+                    } else {
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Theme.answerSurface)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+                    }
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .strokeBorder(isFocused ? Color.clear : Theme.answerBorder, lineWidth: 3)
+                )
+                .shadow(color: isFocused ? Theme.focusShadow : .clear, radius: 25, y: 20)
+                .scaleEffect(isFocused ? 1.07 : 1.0)
+                .animation(Theme.focusAnimation, value: isFocused)
+        }
+    }
 }

--- a/Wanderback/Views/ContentView.swift
+++ b/Wanderback/Views/ContentView.swift
@@ -2,53 +2,111 @@ import SwiftUI
 import SwiftData
 
 struct ContentView: View {
-    @State private var viewModel = PhotoLibraryViewModel()
+    @State private var photoViewModel = PhotoLibraryViewModel()
+    @State private var gameViewModel = GameViewModel()
     @Environment(\.modelContext) private var modelContext
 
     var body: some View {
+        ZStack {
+            SceneBackground()
+            content
+        }
+        .preferredColorScheme(.dark)
+        .animation(.easeInOut(duration: 0.35), value: gameViewModel.phase)
+        .task {
+            await photoViewModel.requestAccessAndLoadPhotos(modelContext: modelContext)
+            jumpToScreenIfRequested()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = photoViewModel.errorMessage {
+            errorView(message: error)
+        } else if photoViewModel.notEnoughPhotos {
+            NotEnoughPlacesView(viewModel: photoViewModel)
+        } else if gameViewModel.session != nil {
+            gameFlow
+        } else if photoViewModel.isReady {
+            HomeView(viewModel: photoViewModel) { mode, roundCount in
+                gameViewModel.startGame(
+                    mode: mode,
+                    roundCount: roundCount,
+                    clusters: photoViewModel.clusters
+                )
+            }
+        } else {
+            LoadingView(viewModel: photoViewModel)
+        }
+    }
+
+    /// Boucle de jeu : GameView → RevealView (par round) → SummaryView.
+    /// Le bouton Menu de la télécommande ramène à l'accueil.
+    @ViewBuilder
+    private var gameFlow: some View {
         Group {
-            if let error = viewModel.errorMessage {
-                errorView(message: error)
-            } else if viewModel.notEnoughPhotos {
-                notEnoughPhotosView
-            } else if viewModel.isReady {
-                HomeView(viewModel: viewModel)
-            } else {
-                LoadingView(viewModel: viewModel)
+            switch gameViewModel.phase {
+            case .playing:
+                GameView(gameViewModel: gameViewModel)
+                    .transition(.opacity)
+            case .revealing:
+                RevealView(gameViewModel: gameViewModel)
+                    .transition(.opacity)
+            case .finished:
+                SummaryView(gameViewModel: gameViewModel) {
+                    gameViewModel.quit()
+                }
+                .transition(.opacity)
             }
         }
-        .task {
-            await viewModel.requestAccessAndLoadPhotos(modelContext: modelContext)
+        .onExitCommand {
+            gameViewModel.quit()
         }
+    }
+
+    /// Dev uniquement : `-screen game|reveal|summary` saute directement à un écran
+    /// (à combiner avec `-demoMode`) pour vérifier visuellement les rendus.
+    private func jumpToScreenIfRequested() {
+        #if DEBUG
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let flagIndex = arguments.firstIndex(of: "-screen"),
+              arguments.count > flagIndex + 1,
+              photoViewModel.isReady else { return }
+
+        let target = arguments[flagIndex + 1]
+        gameViewModel.startGame(mode: .challenge, roundCount: 3, clusters: photoViewModel.clusters)
+
+        switch target {
+        case "reveal":
+            if let round = gameViewModel.currentRound {
+                gameViewModel.answer(round.correctAnswer)
+            }
+        case "summary":
+            while gameViewModel.phase != .finished, let round = gameViewModel.currentRound {
+                gameViewModel.answer(round.correctAnswer)
+                gameViewModel.nextRound()
+            }
+        default:
+            break // "game" : rien à faire, la partie est lancée
+        }
+        #endif
     }
 
     private func errorView(message: String) -> some View {
-        VStack(spacing: 20) {
-            Image(systemName: "photo.on.rectangle.angled")
-                .font(.system(size: 80))
-                .foregroundStyle(.secondary)
+        VStack(spacing: 32) {
+            ZStack {
+                Circle()
+                    .fill(Color.white.opacity(0.07))
+                    .frame(width: 120, height: 120)
+                Image(systemName: "photo.on.rectangle.angled")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Theme.textSecondary)
+            }
             Text(message)
-                .font(.system(size: 32))
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 80)
-        }
-    }
-
-    private var notEnoughPhotosView: some View {
-        VStack(spacing: 24) {
-            Image(systemName: "map.circle")
-                .font(.system(size: 80))
-                .foregroundStyle(.orange)
-            Text("Pas assez de photos géolocalisées")
-                .font(.system(size: 38, weight: .semibold))
-            Text("Wanderback a besoin d'au moins \(PhotoIndexer.minimumDistinctLocations) lieux distincts pour fonctionner.")
                 .font(.system(size: 28))
+                .foregroundStyle(Theme.textSecondary)
                 .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 80)
-            Text(viewModel.gpsStatsText)
-                .font(.system(size: 24))
-                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 200)
         }
     }
 }

--- a/Wanderback/Views/GameView.swift
+++ b/Wanderback/Views/GameView.swift
@@ -1,11 +1,153 @@
 import SwiftUI
 
 struct GameView: View {
-    var body: some View {
-        Text("Game")
-    }
-}
+    let gameViewModel: GameViewModel
 
-#Preview {
-    GameView()
+    @State private var roundImage: UIImage?
+    @State private var loadedRoundId: UUID?
+
+    private let scrimColor = Color(red: 10 / 255, green: 9 / 255, blue: 20 / 255)
+
+    var body: some View {
+        ZStack {
+            photoBackground
+            scrim
+
+            VStack {
+                topBar
+                Spacer()
+                bottomSection
+            }
+        }
+        .ignoresSafeArea()
+        .task(id: gameViewModel.currentRound?.id) {
+            await loadRoundPhoto()
+        }
+    }
+
+    // MARK: - Photo plein écran
+
+    @ViewBuilder
+    private var photoBackground: some View {
+        if let roundImage, loadedRoundId == gameViewModel.currentRound?.id {
+            GeometryReader { geometry in
+                Image(uiImage: roundImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .clipped()
+            }
+            .transition(.opacity)
+        } else {
+            // Placeholder pendant le chargement (et pour le mode démo sans vraie photo)
+            LinearGradient(
+                colors: [Color(hex: 0x8FB6C9), Color(hex: 0xC9976B), Color(hex: 0x4A3428)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+
+    /// Scrim vertical : sombre en haut, transparent au centre, très sombre en bas.
+    private var scrim: some View {
+        LinearGradient(
+            stops: [
+                .init(color: scrimColor.opacity(0.6), location: 0),
+                .init(color: .clear, location: 0.18),
+                .init(color: .clear, location: 0.52),
+                .init(color: scrimColor.opacity(0.92), location: 1)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    // MARK: - Barre haute
+
+    private var topBar: some View {
+        HStack {
+            GradientText(text: "WANDERBACK", size: 28, tracking: -0.5)
+
+            Spacer()
+
+            HStack(spacing: 32) {
+                Text("Round \(Text("\(currentRoundNumber)").bold())/\(totalRounds)")
+                    .font(.system(size: 24))
+                    .foregroundStyle(Theme.textSecondary)
+
+                if gameViewModel.mode == .challenge {
+                    timerRing
+
+                    Text("\(gameViewModel.score.formatted(.number.grouping(.automatic))) pts")
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(Theme.amber)
+                }
+            }
+        }
+        .padding(.horizontal, 56)
+        .padding(.vertical, 36)
+    }
+
+    /// Anneau chrono 68×68 : l'arc ambre se vide avec le temps.
+    private var timerRing: some View {
+        let progress = gameViewModel.timerRemaining / GameViewModel.roundDuration
+        return ZStack {
+            Circle()
+                .fill(Color(red: 10 / 255, green: 9 / 255, blue: 20 / 255).opacity(0.85))
+            Circle()
+                .stroke(Color.white.opacity(0.12), lineWidth: 5)
+                .padding(3)
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(Theme.amber, style: StrokeStyle(lineWidth: 5, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .padding(3)
+            Text("\(Int(gameViewModel.timerRemaining.rounded(.up)))")
+                .font(.system(size: 24, weight: .heavy))
+                .foregroundStyle(.white)
+                .contentTransition(.numericText(countsDown: true))
+        }
+        .frame(width: 68, height: 68)
+    }
+
+    // MARK: - Question + réponses
+
+    private var bottomSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text("Où cette photo a-t-elle été prise ?")
+                .font(.system(size: 26))
+                .foregroundStyle(.white)
+
+            if let round = gameViewModel.currentRound {
+                AnswerOptionsView(options: round.options) { option in
+                    gameViewModel.answer(option)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 56)
+        .padding(.bottom, 44)
+    }
+
+    private var currentRoundNumber: Int {
+        guard let session = gameViewModel.session else { return 0 }
+        return min(session.currentRoundIndex + 1, session.rounds.count)
+    }
+
+    private var totalRounds: Int {
+        gameViewModel.session?.rounds.count ?? 0
+    }
+
+    private func loadRoundPhoto() async {
+        guard let round = gameViewModel.currentRound else { return }
+        roundImage = nil
+        let image = await PhotoImageLoader.shared.loadImage(
+            assetIdentifier: round.photo.assetIdentifier,
+            targetSize: CGSize(width: 1920, height: 1080)
+        )
+        withAnimation(.easeIn(duration: 0.3)) {
+            roundImage = image
+            loadedRoundId = round.id
+        }
+    }
 }

--- a/Wanderback/Views/HomeView.swift
+++ b/Wanderback/Views/HomeView.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 struct HomeView: View {
     let viewModel: PhotoLibraryViewModel
+    let onPlay: (GameMode, Int) -> Void
 
     @State private var selectedMode: GameMode = .souvenir
     @State private var selectedRounds: Int = 10
+    @State private var mosaicImages: [UIImage] = []
     @FocusState private var focusedElement: HomeElement?
 
     private let roundOptions = [5, 10, 20]
@@ -16,146 +18,249 @@ struct HomeView: View {
     }
 
     var body: some View {
-        VStack(spacing: 50) {
-            // Header
-            header
+        ZStack {
+            SceneBackground()
+            mosaicBackground
 
-            // Stats
-            statsRow
-
-            // Mode selection
-            modeSelection
-
-            // Rounds selection
-            roundsSelection
-
-            // Play button
-            playButton
+            VStack(spacing: 44) {
+                header
+                modeSelection
+                roundsSelection
+                statsRow
+                playButton
+            }
         }
-        .padding(80)
         .defaultFocus($focusedElement, .play)
+        .task {
+            mosaicImages = await PhotoImageLoader.shared.loadRandomImages(
+                from: viewModel.photoLocations,
+                count: 10,
+                targetSize: CGSize(width: 500, height: 400)
+            )
+        }
+    }
+
+    // MARK: - Fond mosaïque
+
+    /// Mosaïque 5×2 des photos de l'utilisateur, opacité 0,6, sous un voile radial sombre.
+    private var mosaicBackground: some View {
+        GeometryReader { geometry in
+            let columns = 5, rows = 2
+            let gap: CGFloat = 6
+            let cellWidth = (geometry.size.width - gap * CGFloat(columns - 1)) / CGFloat(columns)
+            let cellHeight = (geometry.size.height - gap) / CGFloat(rows)
+
+            VStack(spacing: gap) {
+                ForEach(0..<rows, id: \.self) { row in
+                    HStack(spacing: gap) {
+                        ForEach(0..<columns, id: \.self) { column in
+                            mosaicCell(index: row * columns + column)
+                                .frame(width: cellWidth, height: cellHeight)
+                                .clipped()
+                        }
+                    }
+                }
+            }
+            .opacity(0.6)
+            .overlay(
+                RadialGradient(
+                    colors: [
+                        Color(hex: 0x232048).opacity(0.88),
+                        Color(hex: 0x131226).opacity(0.96)
+                    ],
+                    center: .center,
+                    startRadius: 200,
+                    endRadius: 1300
+                )
+            )
+        }
+        .ignoresSafeArea()
+    }
+
+    @ViewBuilder
+    private func mosaicCell(index: Int) -> some View {
+        if index < mosaicImages.count {
+            Image(uiImage: mosaicImages[index])
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            LinearGradient(
+                colors: [Theme.backgroundTop, Theme.backgroundBottom],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
     }
 
     // MARK: - Header
 
     private var header: some View {
-        VStack(spacing: 12) {
-            Text("Wanderback")
-                .font(.system(size: 60, weight: .bold))
-            Text("Devinez où ont été prises vos photos")
-                .font(.system(size: 28))
-                .foregroundStyle(.secondary)
+        VStack(spacing: 14) {
+            GradientText(text: "WANDERBACK", size: 84, tracking: -2)
+            Text("Le quiz de VOS voyages")
+                .font(.system(size: 27))
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    // MARK: - Tuiles mode
+
+    private var modeSelection: some View {
+        HStack(spacing: 34) {
+            ForEach(GameMode.allCases) { mode in
+                Button {
+                    withAnimation(Theme.focusAnimation) { selectedMode = mode }
+                } label: {
+                    modeTileLabel(mode)
+                }
+                .buttonStyle(ModeTileButtonStyle(isSelected: selectedMode == mode, mode: mode))
+                .focused($focusedElement, equals: .mode(mode))
+            }
+        }
+    }
+
+    private func modeTileLabel(_ mode: GameMode) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Image(systemName: mode.icon)
+                .font(.system(size: 24))
+                .foregroundStyle(.white)
+                .frame(width: 52, height: 52)
+                .background(Color.white.opacity(0.25), in: Circle())
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(mode.title)
+                    .font(.system(size: 34, weight: .heavy))
+                Text(mode.subtitle)
+                    .font(.system(size: 22))
+                    .foregroundStyle(.white.opacity(0.75))
+            }
+        }
+        .foregroundStyle(.white)
+        .frame(width: 500 - 2 * 34, alignment: .leading)
+        .padding(34)
+    }
+
+    // MARK: - Rounds
+
+    private var roundsSelection: some View {
+        HStack(spacing: 28) {
+            Text("Rounds")
+                .font(.system(size: 24))
+                .foregroundStyle(Theme.textSecondary)
+
+            ForEach(roundOptions, id: \.self) { count in
+                Button {
+                    withAnimation(Theme.focusAnimation) { selectedRounds = count }
+                } label: {
+                    Text("\(count)")
+                        .font(.system(size: 32, weight: .heavy))
+                }
+                .buttonStyle(RoundCircleButtonStyle(isSelected: selectedRounds == count))
+                .focused($focusedElement, equals: .rounds(count))
+            }
         }
     }
 
     // MARK: - Stats
 
     private var statsRow: some View {
-        HStack(spacing: 60) {
-            statItem(
-                icon: "photo.fill",
-                value: "\(viewModel.photoLocations.count)",
-                label: "photos GPS"
-            )
-            statItem(
-                icon: "mappin.and.ellipse",
-                value: "\(viewModel.clusterCount)",
-                label: "lieux"
-            )
-            statItem(
-                icon: "flag.fill",
-                value: "\(viewModel.countryCount)",
-                label: "pays"
-            )
+        HStack(spacing: 52) {
+            Text("\(viewModel.photoLocations.count) photos GPS")
+            Text("\(viewModel.clusterCount) lieux")
+            Text("\(viewModel.countryCount) pays")
         }
+        .font(.system(size: 22))
+        .foregroundStyle(Theme.textTertiary)
     }
 
-    private func statItem(icon: String, value: String, label: String) -> some View {
-        VStack(spacing: 8) {
-            Image(systemName: icon)
-                .font(.system(size: 32))
-                .foregroundStyle(.blue)
-            Text(value)
-                .font(.system(size: 40, weight: .bold))
-            Text(label)
-                .font(.system(size: 22))
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    // MARK: - Mode Selection
-
-    private var modeSelection: some View {
-        VStack(spacing: 16) {
-            Text("Mode de jeu")
-                .font(.system(size: 28, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 30) {
-                ForEach(GameMode.allCases) { mode in
-                    Button {
-                        selectedMode = mode
-                    } label: {
-                        HStack(spacing: 16) {
-                            Image(systemName: mode.icon)
-                                .font(.system(size: 28))
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(mode.title)
-                                    .font(.system(size: 28, weight: .semibold))
-                                Text(mode.subtitle)
-                                    .font(.system(size: 20))
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .padding(.horizontal, 30)
-                        .padding(.vertical, 20)
-                    }
-                    .focused($focusedElement, equals: .mode(mode))
-                    .opacity(selectedMode == mode ? 1.0 : 0.5)
-                }
-            }
-        }
-    }
-
-    // MARK: - Rounds Selection
-
-    private var roundsSelection: some View {
-        VStack(spacing: 16) {
-            Text("Nombre de rounds")
-                .font(.system(size: 28, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 30) {
-                ForEach(roundOptions, id: \.self) { count in
-                    Button {
-                        selectedRounds = count
-                    } label: {
-                        Text("\(count)")
-                            .font(.system(size: 36, weight: .bold))
-                            .frame(width: 120, height: 80)
-                    }
-                    .focused($focusedElement, equals: .rounds(count))
-                    .opacity(selectedRounds == count ? 1.0 : 0.5)
-                }
-            }
-        }
-    }
-
-    // MARK: - Play Button
+    // MARK: - CTA
 
     private var playButton: some View {
         Button {
-            // TODO: Navigation vers GameView (issue #8)
+            onPlay(selectedMode, selectedRounds)
         } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: 16) {
+                Text("C'EST PARTI")
+                    .tracking(2)
                 Image(systemName: "play.fill")
-                    .font(.system(size: 28))
-                Text("Jouer")
-                    .font(.system(size: 32, weight: .bold))
+                    .font(.system(size: 24))
             }
-            .padding(.horizontal, 60)
-            .padding(.vertical, 20)
         }
+        .buttonStyle(GradientPillButtonStyle())
         .focused($focusedElement, equals: .play)
     }
+}
+
+// MARK: - Styles
+
+/// Tuile mode 500pt : dégradé sombre par mode, bordure blanche 4pt si sélectionnée.
+private struct ModeTileButtonStyle: ButtonStyle {
+    let isSelected: Bool
+    let mode: GameMode
+
+    func makeBody(configuration: Configuration) -> some View {
+        ModeTileLabel(configuration: configuration, isSelected: isSelected, mode: mode)
+    }
+
+    private struct ModeTileLabel: View {
+        @Environment(\.isFocused) private var isFocused
+        let configuration: ButtonStyle.Configuration
+        let isSelected: Bool
+        let mode: GameMode
+
+        var body: some View {
+            configuration.label
+                .background(
+                    mode == .souvenir ? Theme.souvenirTileGradient : Theme.challengeTileGradient,
+                    in: RoundedRectangle(cornerRadius: 28)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 28)
+                        .strokeBorder(
+                            Color.white.opacity(isSelected ? 1 : (isFocused ? 0.5 : 0)),
+                            lineWidth: 4
+                        )
+                )
+                .opacity(isSelected || isFocused ? 1 : 0.65)
+                .shadow(color: Theme.tileShadow, radius: 30, y: 24)
+                .scaleEffect(isFocused ? 1.08 : (isSelected ? 1.04 : 1.0))
+                .animation(Theme.focusAnimation, value: isFocused)
+                .animation(Theme.focusAnimation, value: isSelected)
+        }
+    }
+}
+
+/// Cercle rounds 96×96 : fond blanc + texte sombre si sélectionné.
+private struct RoundCircleButtonStyle: ButtonStyle {
+    let isSelected: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        RoundCircleLabel(configuration: configuration, isSelected: isSelected)
+    }
+
+    private struct RoundCircleLabel: View {
+        @Environment(\.isFocused) private var isFocused
+        let configuration: ButtonStyle.Configuration
+        let isSelected: Bool
+
+        var body: some View {
+            let highlighted = isSelected || isFocused
+            configuration.label
+                .foregroundStyle(highlighted ? Theme.inkDark : .white)
+                .frame(width: 96, height: 96)
+                .background(
+                    highlighted ? Color.white : Color.white.opacity(0.08),
+                    in: Circle()
+                )
+                .opacity(highlighted ? 1 : 0.6)
+                .shadow(color: isFocused ? Theme.focusShadow : .clear, radius: 25, y: 20)
+                .scaleEffect(isFocused ? 1.1 : 1.0)
+                .animation(Theme.focusAnimation, value: isFocused)
+                .animation(Theme.focusAnimation, value: isSelected)
+        }
+    }
+}
+
+#Preview {
+    HomeView(viewModel: PhotoLibraryViewModel()) { _, _ in }
 }

--- a/Wanderback/Views/LoadingView.swift
+++ b/Wanderback/Views/LoadingView.swift
@@ -3,42 +3,82 @@ import SwiftUI
 struct LoadingView: View {
     let viewModel: PhotoLibraryViewModel
 
+    @State private var isPulsing = false
+
     var body: some View {
-        VStack(spacing: 40) {
-            Spacer()
+        ZStack {
+            SceneBackground()
 
-            Image(systemName: "globe.desk")
-                .font(.system(size: 80))
-                .foregroundStyle(.blue)
-                .symbolEffect(.pulse)
+            VStack(spacing: 44) {
+                globe
 
-            Text("Wanderback")
-                .font(.system(size: 56, weight: .bold))
+                GradientText(text: "WANDERBACK", size: 76, tracking: -2)
 
-            VStack(spacing: 30) {
-                Text(viewModel.currentStep.label)
-                    .font(.system(size: 32))
-                    .foregroundStyle(.secondary)
+                Text("Analyse de vos photos…")
+                    .font(.system(size: 28))
+                    .foregroundStyle(Theme.textSecondary)
 
-                if let progress = viewModel.currentStep.progress {
-                    ProgressView(value: progress)
-                        .progressViewStyle(.linear)
-                        .frame(width: 500)
-                        .animation(.easeInOut, value: progress)
-                } else {
-                    ProgressView()
-                        .scaleEffect(1.5)
+                progressBar
+
+                VStack(spacing: 20) {
+                    Text(viewModel.currentStep.label)
+                        .font(.system(size: 24))
+                        .foregroundStyle(Theme.textSecondary)
+                        .contentTransition(.numericText())
+                        .animation(.default, value: viewModel.currentStep.label)
+
+                    if viewModel.totalPhotoCount > 0 {
+                        Text(viewModel.gpsStatsText)
+                            .font(.system(size: 24))
+                            .foregroundStyle(Theme.textTertiary)
+                    }
                 }
             }
-
-            if viewModel.totalPhotoCount > 0 {
-                Text(viewModel.gpsStatsText)
-                    .font(.system(size: 24))
-                    .foregroundStyle(.tertiary)
-            }
-
-            Spacer()
         }
-        .padding(80)
+        .onAppear { isPulsing = true }
     }
+
+    /// Globe 140×140 : cercle dégradé ambre→rose, halo rose, pulsation 2,2 s
+    private var globe: some View {
+        Circle()
+            .fill(Theme.signatureGradient)
+            .frame(width: 140, height: 140)
+            .overlay(
+                Circle()
+                    .strokeBorder(Color.white.opacity(0.9), lineWidth: 8)
+                    .frame(width: 64, height: 64)
+            )
+            .shadow(color: Theme.rose.opacity(0.5), radius: 90)
+            .scaleEffect(isPulsing ? 1.12 : 1.0)
+            .animation(.easeInOut(duration: 2.2).repeatForever(autoreverses: true), value: isPulsing)
+    }
+
+    /// Barre 900×12, pilule, remplissage dégradé signature
+    private var progressBar: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.white.opacity(0.1))
+
+            if let progress = viewModel.currentStep.progress {
+                GeometryReader { geometry in
+                    Capsule()
+                        .fill(Theme.signatureGradient)
+                        .frame(width: max(12, geometry.size.width * progress))
+                        .animation(.easeInOut(duration: 0.3), value: progress)
+                }
+            } else {
+                // Progression indéterminée : segment qui pulse
+                Capsule()
+                    .fill(Theme.signatureGradient)
+                    .frame(width: 200)
+                    .opacity(isPulsing ? 0.9 : 0.3)
+                    .animation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true), value: isPulsing)
+            }
+        }
+        .frame(width: 900, height: 12)
+    }
+}
+
+#Preview {
+    LoadingView(viewModel: PhotoLibraryViewModel())
 }

--- a/Wanderback/Views/NotEnoughPlacesView.swift
+++ b/Wanderback/Views/NotEnoughPlacesView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+/// Écran d'erreur : pas assez de destinations distinctes pour jouer.
+struct NotEnoughPlacesView: View {
+    let viewModel: PhotoLibraryViewModel
+
+    @State private var showingHelp = false
+    @FocusState private var demoFocused: Bool
+
+    var body: some View {
+        ZStack {
+            SceneBackground()
+
+            VStack(spacing: 32) {
+                badge
+
+                Text("Pas assez de destinations trouvées")
+                    .font(.system(size: 52, weight: .heavy))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+
+                Text(bodyText)
+                    .font(.system(size: 28))
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+
+                tipCard
+
+                HStack(spacing: 30) {
+                    Button("Voir comment faire") {
+                        withAnimation(Theme.focusAnimation) { showingHelp.toggle() }
+                    }
+                    .buttonStyle(SecondaryPillButtonStyle(horizontalPadding: 44, verticalPadding: 18, fontSize: 24))
+
+                    Button {
+                        viewModel.startDemoMode()
+                    } label: {
+                        HStack(spacing: 12) {
+                            Text("Mode démo")
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 18))
+                        }
+                    }
+                    .buttonStyle(GradientPillButtonStyle(horizontalPadding: 44, verticalPadding: 18, fontSize: 24))
+                    .focused($demoFocused)
+                }
+                .padding(.top, 8)
+            }
+            .padding(.horizontal, 200)
+        }
+        .defaultFocus($demoFocused, true)
+    }
+
+    /// Pastille 120 : cercle translucide + point erreur.
+    private var badge: some View {
+        ZStack {
+            Circle()
+                .fill(Color.white.opacity(0.07))
+                .frame(width: 120, height: 120)
+            Circle()
+                .fill(Theme.error.opacity(0.3))
+                .frame(width: 52, height: 52)
+            Circle()
+                .fill(Theme.error)
+                .frame(width: 26, height: 26)
+        }
+    }
+
+    private var bodyText: String {
+        let found = viewModel.clusters.count
+        let minimum = ClusteringService.minimumClusters
+        if found > 0 {
+            return "Wanderback a trouvé seulement \(found) lieu\(found > 1 ? "x" : "") dans tes photos.\nIl en faut au moins \(minimum) différents pour jouer."
+        }
+        return "Wanderback n'a pas trouvé de photos géolocalisées dans ta bibliothèque.\nIl faut au moins \(minimum) lieux différents pour jouer."
+    }
+
+    private var tipCard: some View {
+        Text(showingHelp ? helpText : tipText)
+            .font(.system(size: 24))
+            .foregroundStyle(Theme.textSecondary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 30)
+            .padding(.vertical, 18)
+            .background(Color.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var tipText: String {
+        "Active « Localisation » sur ton iPhone pour tes prochaines photos, et reviens après ton prochain voyage !"
+    }
+
+    private var helpText: String {
+        "Sur ton iPhone : Réglages → Confidentialité et sécurité → Service de localisation → Appareil photo → « Lorsque l'app est active ». Les photos prises ensuite seront géolocalisées et synchronisées via iCloud."
+    }
+}
+
+#Preview {
+    NotEnoughPlacesView(viewModel: PhotoLibraryViewModel())
+}

--- a/Wanderback/Views/RevealView.swift
+++ b/Wanderback/Views/RevealView.swift
@@ -1,11 +1,236 @@
 import SwiftUI
+import MapKit
 
 struct RevealView: View {
-    var body: some View {
-        Text("Reveal")
-    }
-}
+    let gameViewModel: GameViewModel
 
-#Preview {
-    RevealView()
+    @State private var cameraPosition: MapCameraPosition
+    @State private var contentRevealed = false
+    @State private var sameDayImages: [UIImage] = []
+    @FocusState private var nextButtonFocused: Bool
+
+    init(gameViewModel: GameViewModel) {
+        self.gameViewModel = gameViewModel
+        // Départ du zoom cinématique : vue très éloignée centrée sur le lieu
+        if let coordinate = gameViewModel.currentRound?.correctAnswer.centerCoordinate {
+            _cameraPosition = State(initialValue: .camera(
+                MapCamera(centerCoordinate: coordinate, distance: 18_000_000)
+            ))
+        } else {
+            _cameraPosition = State(initialValue: .automatic)
+        }
+    }
+
+    private var round: GameRound? { gameViewModel.currentRound }
+    private var isCorrect: Bool { round?.isCorrect == true }
+
+    var body: some View {
+        ZStack {
+            map
+            vignette
+
+            VStack {
+                resultBadge
+                    .padding(.top, 44)
+                Spacer()
+            }
+
+            centerContent
+
+            VStack {
+                Spacer()
+                HStack(alignment: .bottom) {
+                    sameDayThumbnails
+                    Spacer()
+                    nextButton
+                }
+                .padding(.horizontal, 56)
+                .padding(.bottom, 44)
+            }
+        }
+        .ignoresSafeArea()
+        .defaultFocus($nextButtonFocused, true)
+        .onAppear { startCinematicZoom() }
+        .task { await loadSameDayPhotos() }
+    }
+
+    // MARK: - Carte + zoom cinématique
+
+    private var map: some View {
+        Map(position: $cameraPosition, interactionModes: []) {
+            if let coordinate = round?.correctAnswer.centerCoordinate {
+                Annotation("", coordinate: coordinate) {
+                    pin
+                }
+            }
+        }
+        .mapStyle(.standard(elevation: .realistic, pointsOfInterest: .excludingAll))
+    }
+
+    /// Pin 28pt : cercle erreur + halo à 30 %.
+    private var pin: some View {
+        ZStack {
+            Circle()
+                .fill(Theme.error.opacity(0.3))
+                .frame(width: 56, height: 56)
+            Circle()
+                .fill(Theme.error)
+                .frame(width: 28, height: 28)
+                .overlay(Circle().strokeBorder(.white.opacity(0.85), lineWidth: 3))
+        }
+    }
+
+    /// Vignette radiale sombre sur les bords de la carte.
+    private var vignette: some View {
+        RadialGradient(
+            stops: [
+                .init(color: Theme.backgroundBottom.opacity(0.25), location: 0),
+                .init(color: Theme.backgroundBottom.opacity(0.4), location: 0.5),
+                .init(color: Theme.backgroundBottom.opacity(0.88), location: 1)
+            ],
+            center: .center,
+            startRadius: 200,
+            endRadius: 1200
+        )
+        .allowsHitTesting(false)
+    }
+
+    private func startCinematicZoom() {
+        guard let coordinate = round?.correctAnswer.centerCoordinate else { return }
+
+        // Zoom ~2–3 s en Souvenir, abrégé en Challenge
+        let duration: TimeInterval = gameViewModel.mode == .challenge ? 1.6 : 2.6
+        withAnimation(.easeInOut(duration: duration)) {
+            cameraPosition = .camera(
+                MapCamera(centerCoordinate: coordinate, distance: 250_000, pitch: 0)
+            )
+        }
+        withAnimation(.easeOut(duration: 0.5).delay(duration * 0.4)) {
+            contentRevealed = true
+        }
+    }
+
+    // MARK: - Badge résultat
+
+    private var resultBadge: some View {
+        HStack(spacing: 10) {
+            Image(systemName: isCorrect ? "checkmark" : "xmark")
+                .font(.system(size: 22, weight: .heavy))
+            Text(isCorrect ? "Bonne réponse !" : "C'était…")
+                .font(.system(size: 26, weight: .heavy))
+        }
+        .foregroundStyle(Theme.inkDark)
+        .padding(.horizontal, 36)
+        .padding(.vertical, 16)
+        .background(isCorrect ? Theme.success : Theme.error, in: Capsule())
+        .shadow(color: Theme.tileShadow, radius: 20, y: 12)
+    }
+
+    // MARK: - Contenu central
+
+    private var centerContent: some View {
+        VStack(spacing: 16) {
+            Text(round?.correctAnswer.displayName.uppercased() ?? "")
+                .font(.system(size: 104, weight: .heavy))
+                .tracking(4)
+                .foregroundStyle(.white)
+                .shadow(color: .black.opacity(0.6), radius: 30, y: 10)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+                .padding(.horizontal, 100)
+
+            Text(round?.correctAnswer.country ?? "")
+                .font(.system(size: 32))
+                .foregroundStyle(.white.opacity(0.85))
+
+            Text(metaText)
+                .font(.system(size: 24))
+                .foregroundStyle(Theme.textSecondary)
+
+            if gameViewModel.mode == .challenge {
+                Text("+\(gameViewModel.lastPointsEarned) pts")
+                    .font(.system(size: 30, weight: .heavy))
+                    .foregroundStyle(Theme.amber)
+                    .padding(.top, 8)
+            }
+        }
+        .padding(.top, 260) // dégage le pin, qui reste au centre exact de la carte
+        .opacity(contentRevealed ? 1 : 0)
+        .offset(y: contentRevealed ? 0 : 30)
+    }
+
+    private var metaText: String {
+        var parts: [String] = []
+        if let date = round?.photo.dateTaken {
+            parts.append(date.formatted(
+                Date.FormatStyle(date: .long, time: .omitted, locale: Locale(identifier: "fr_FR"))
+            ))
+        }
+        if let km = gameViewModel.distanceFromHomeKm {
+            parts.append("\(km.formatted(.number.grouping(.automatic))) km de chez vous")
+        }
+        return parts.joined(separator: "  ·  ")
+    }
+
+    // MARK: - Vignettes du même jour
+
+    @ViewBuilder
+    private var sameDayThumbnails: some View {
+        if !sameDayImages.isEmpty {
+            HStack(alignment: .bottom, spacing: 14) {
+                ForEach(Array(sameDayImages.enumerated()), id: \.offset) { _, image in
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 148, height: 100)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 14)
+                                .strokeBorder(.white.opacity(0.2), lineWidth: 2)
+                        )
+                }
+
+                Text("photos du\nmême jour")
+                    .font(.system(size: 19))
+                    .foregroundStyle(Theme.textTertiary)
+                    .padding(.leading, 6)
+            }
+            .opacity(contentRevealed ? 1 : 0)
+        }
+    }
+
+    private func loadSameDayPhotos() async {
+        guard let round else { return }
+        let calendar = Calendar.current
+        let sameDay = round.correctAnswer.photos
+            .filter { calendar.isDate($0.dateTaken, inSameDayAs: round.photo.dateTaken) }
+            .prefix(3)
+
+        var images: [UIImage] = []
+        for photo in sameDay {
+            if let image = await PhotoImageLoader.shared.loadImage(
+                assetIdentifier: photo.assetIdentifier,
+                targetSize: CGSize(width: 296, height: 200)
+            ) {
+                images.append(image)
+            }
+        }
+        sameDayImages = images
+    }
+
+    // MARK: - Bouton suivant
+
+    private var nextButton: some View {
+        Button {
+            gameViewModel.nextRound()
+        } label: {
+            HStack(spacing: 12) {
+                Text(gameViewModel.isLastRound ? "Voir le récap" : "Round suivant")
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 22, weight: .bold))
+            }
+        }
+        .buttonStyle(GradientPillButtonStyle(horizontalPadding: 48, verticalPadding: 20, fontSize: 26))
+        .focused($nextButtonFocused)
+    }
 }

--- a/Wanderback/Views/SummaryView.swift
+++ b/Wanderback/Views/SummaryView.swift
@@ -1,11 +1,124 @@
 import SwiftUI
+import MapKit
 
 struct SummaryView: View {
-    var body: some View {
-        Text("Summary")
-    }
-}
+    let gameViewModel: GameViewModel
+    /// Retour à l'accueil pour changer de mode
+    let onChangeMode: () -> Void
 
-#Preview {
-    SummaryView()
+    @FocusState private var replayFocused: Bool
+
+    private var rounds: [GameRound] { gameViewModel.session?.rounds ?? [] }
+
+    var body: some View {
+        ZStack {
+            worldMap
+            mapVeil
+
+            VStack(spacing: 36) {
+                Spacer()
+
+                VStack(spacing: 10) {
+                    Text("Partie terminée !")
+                        .font(.system(size: 30, weight: .bold))
+                        .foregroundStyle(.white)
+
+                    GradientText(text: finalScoreText, size: 96)
+
+                    Text(scoreSubtitle)
+                        .font(.system(size: 26))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                statsLine
+
+                HStack(spacing: 30) {
+                    Button {
+                        gameViewModel.replay()
+                    } label: {
+                        HStack(spacing: 14) {
+                            Text("Rejouer")
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 20))
+                        }
+                    }
+                    .buttonStyle(GradientPillButtonStyle(horizontalPadding: 56, verticalPadding: 20, fontSize: 26))
+                    .focused($replayFocused)
+
+                    Button("Changer de mode") {
+                        onChangeMode()
+                    }
+                    .buttonStyle(SecondaryPillButtonStyle())
+                }
+            }
+            .padding(.bottom, 70)
+        }
+        .ignoresSafeArea()
+        .defaultFocus($replayFocused, true)
+    }
+
+    // MARK: - Carte du monde avec les lieux joués
+
+    private var worldMap: some View {
+        Map(initialPosition: .automatic, interactionModes: []) {
+            ForEach(Array(rounds.enumerated()), id: \.element.id) { index, round in
+                Annotation("", coordinate: round.correctAnswer.centerCoordinate) {
+                    summaryPin(color: index.isMultiple(of: 2) ? Theme.amber : Theme.rose)
+                }
+            }
+        }
+        .mapStyle(.standard(pointsOfInterest: .excludingAll))
+    }
+
+    /// Pin ambre/rose alterné avec halo à 25 %.
+    private func summaryPin(color: Color) -> some View {
+        ZStack {
+            Circle()
+                .fill(color.opacity(0.25))
+                .frame(width: 40, height: 40)
+            Circle()
+                .fill(color)
+                .frame(width: 20, height: 20)
+                .overlay(Circle().strokeBorder(.white.opacity(0.7), lineWidth: 2))
+        }
+    }
+
+    /// Voile sombre pour garder la carte en arrière-plan discret.
+    private var mapVeil: some View {
+        LinearGradient(
+            stops: [
+                .init(color: Theme.backgroundBottom.opacity(0.75), location: 0),
+                .init(color: Theme.backgroundBottom.opacity(0.55), location: 0.4),
+                .init(color: Theme.backgroundBottom.opacity(0.96), location: 1)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .allowsHitTesting(false)
+    }
+
+    // MARK: - Score
+
+    private var finalScoreText: String {
+        if gameViewModel.mode == .challenge {
+            return "\(gameViewModel.score.formatted(.number.grouping(.automatic))) pts"
+        }
+        return "\(gameViewModel.correctAnswersCount)/\(rounds.count)"
+    }
+
+    private var scoreSubtitle: String {
+        gameViewModel.mode == .challenge
+            ? "Score final — mode Challenge"
+            : "Quel beau voyage — mode Souvenir"
+    }
+
+    private var statsLine: some View {
+        HStack(spacing: 56) {
+            Text("\(Text("\(gameViewModel.correctAnswersCount)/\(rounds.count)").bold()) bonnes réponses")
+            Text("\(Text("\(gameViewModel.totalDistanceKm.formatted(.number.grouping(.automatic))) km").bold()) parcourus")
+            Text("\(Text("\(gameViewModel.countriesVisitedCount)").bold()) \(gameViewModel.countriesVisitedCount > 1 ? "pays visités" : "pays visité")")
+        }
+        .font(.system(size: 25))
+        .foregroundStyle(Theme.textSecondary)
+    }
 }

--- a/docs/superpowers/plans/2026-03-15-loading-view.md
+++ b/docs/superpowers/plans/2026-03-15-loading-view.md
@@ -1,0 +1,335 @@
+# LoadingView Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remplacer le ProgressView basique par un vrai ecran d'indexation avec progression par etape, compteur, et transition automatique vers HomeView.
+
+**Architecture:** PhotoLibraryViewModel orchestre le pipeline complet (permission -> index -> cluster -> geocode) avec reporting de progression par etape. LoadingView affiche la progression. ContentView devient un routeur d'etat.
+
+**Tech Stack:** SwiftUI, @Observable, SwiftData (ModelContext pour geocoding cache), PhotoKit, CoreLocation
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `Wanderback/ViewModels/PhotoLibraryViewModel.swift` | Pipeline complet + progression |
+| Create | `Wanderback/Views/LoadingView.swift` | UI de progression tvOS |
+| Modify | `Wanderback/Views/ContentView.swift` | Routeur d'etat (error/loading/home) |
+
+---
+
+### Task 1: Enhance PhotoLibraryViewModel with full pipeline and progress
+
+**Files:**
+- Modify: `Wanderback/ViewModels/PhotoLibraryViewModel.swift`
+
+**Context:** Actuellement le ViewModel fait seulement permission + indexation. Il faut ajouter clustering + geocoding avec reporting de progression.
+
+- [ ] **Step 1: Add IndexingStep enum and progress properties**
+
+```swift
+import Foundation
+import Photos
+import SwiftData
+import CoreLocation
+import os
+
+enum IndexingStep: Equatable {
+    case requestingAccess
+    case scanningPhotos
+    case clusteringLocations
+    case geocoding(current: Int, total: Int)
+    case ready
+
+    var label: String {
+        switch self {
+        case .requestingAccess: return "Demande d'acces aux photos..."
+        case .scanningPhotos: return "Analyse des photos..."
+        case .clusteringLocations: return "Regroupement des lieux..."
+        case .geocoding(let current, let total): return "Identification des lieux... (\(current)/\(total))"
+        case .ready: return "Pret !"
+        }
+    }
+
+    var progress: Double? {
+        switch self {
+        case .geocoding(let current, let total) where total > 0:
+            return Double(current) / Double(total)
+        case .ready:
+            return 1.0
+        default:
+            return nil
+        }
+    }
+}
+
+@Observable
+class PhotoLibraryViewModel {
+    var authorizationStatus: PHAuthorizationStatus = .notDetermined
+    var photoLocations: [PhotoLocation] = []
+    var clusters: [LocationCluster] = []
+    var totalPhotoCount = 0
+    var isLoading = false
+    var currentStep: IndexingStep = .requestingAccess
+    var errorMessage: String?
+    var notEnoughPhotos = false
+
+    private let photoIndexer = PhotoIndexer()
+    private let clusteringService = ClusteringService()
+    private let geocoderService = GeocoderService()
+    private let logger = Logger(subsystem: "com.bastien.Wanderback", category: "PhotoLibraryVM")
+
+    var hasAccess: Bool {
+        authorizationStatus == .authorized || authorizationStatus == .limited
+    }
+
+    var isReady: Bool {
+        if case .ready = currentStep { return true }
+        return false
+    }
+
+    var gpsStatsText: String {
+        "\(photoLocations.count) photos avec GPS / \(totalPhotoCount) total"
+    }
+
+    var clusterCount: Int { clusters.count }
+
+    var countryCount: Int {
+        Set(clusters.map(\.country)).subtracting([""]).count
+    }
+
+    func requestAccessAndLoadPhotos(modelContext: ModelContext) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        // Step 1: Permission
+        currentStep = .requestingAccess
+        authorizationStatus = await photoIndexer.requestAuthorization()
+        logger.info("Authorization status: \(self.authorizationStatus.rawValue)")
+
+        switch authorizationStatus {
+        case .authorized, .limited:
+            break
+        case .denied, .restricted:
+            errorMessage = "Wanderback a besoin d'acceder a vos photos pour fonctionner. Autorisez l'acces dans Reglages > Confidentialite > Photos."
+            return
+        case .notDetermined:
+            return
+        @unknown default:
+            return
+        }
+
+        // Step 2: Index photos
+        currentStep = .scanningPhotos
+        let result = await photoIndexer.indexPhotos()
+        totalPhotoCount = result.totalCount
+        photoLocations = result.locations
+
+        if photoLocations.count < PhotoIndexer.minimumDistinctLocations {
+            notEnoughPhotos = true
+            logger.warning("Not enough GPS photos: \(self.photoLocations.count)")
+            return
+        }
+
+        // Step 3: Clustering
+        currentStep = .clusteringLocations
+        clusters = clusteringService.clusterPhotos(photoLocations)
+
+        if clusters.count < ClusteringService.minimumClusters {
+            notEnoughPhotos = true
+            logger.warning("Not enough clusters: \(self.clusters.count)")
+            return
+        }
+
+        // Step 4: Geocoding (le plus long — progress par cluster)
+        currentStep = .geocoding(current: 0, total: clusters.count)
+        for i in clusters.indices {
+            let coord = clusters[i].centerCoordinate
+            if let cache = await geocoderService.reverseGeocode(coordinate: coord, modelContext: modelContext) {
+                clusters[i].displayName = cache.displayName
+                clusters[i].country = cache.country
+            }
+            currentStep = .geocoding(current: i + 1, total: clusters.count)
+        }
+
+        // Step 5: Ready
+        currentStep = .ready
+        logger.info("Indexing complete: \(self.clusters.count) clusters, \(self.countryCount) countries")
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `xcodebuild -project Wanderback.xcodeproj -scheme Wanderback -destination 'platform=tvOS Simulator,name=Apple TV' build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Wanderback/ViewModels/PhotoLibraryViewModel.swift
+git commit -m "feat: add full indexing pipeline with progress to PhotoLibraryViewModel"
+```
+
+---
+
+### Task 2: Create LoadingView with tvOS UI
+
+**Files:**
+- Create: `Wanderback/Views/LoadingView.swift`
+
+**Context:** Ecran d'indexation visible pendant le pipeline. Doit respecter les guidelines tvOS 10-foot UI (polices larges, espacement genereux). Affiche etape, barre de progression, compteur.
+
+- [ ] **Step 1: Create LoadingView**
+
+```swift
+import SwiftUI
+
+struct LoadingView: View {
+    let currentStep: IndexingStep
+    let gpsStatsText: String
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+
+            Image(systemName: "globe.desk")
+                .font(.system(size: 80))
+                .foregroundStyle(.blue)
+                .symbolEffect(.pulse)
+
+            Text("Wanderback")
+                .font(.system(size: 56, weight: .bold))
+
+            VStack(spacing: 20) {
+                Text(currentStep.label)
+                    .font(.system(size: 32))
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                    .animation(.easeInOut, value: currentStep)
+
+                if let progress = currentStep.progress {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .frame(width: 500)
+                        .animation(.easeInOut, value: progress)
+                } else {
+                    ProgressView()
+                        .frame(width: 500)
+                }
+            }
+
+            if !gpsStatsText.isEmpty {
+                Text(gpsStatsText)
+                    .font(.system(size: 24))
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+        }
+        .padding(80)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `xcodebuild -project Wanderback.xcodeproj -scheme Wanderback -destination 'platform=tvOS Simulator,name=Apple TV' build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Wanderback/Views/LoadingView.swift
+git commit -m "feat: add LoadingView with progress bar and step labels"
+```
+
+---
+
+### Task 3: Refactor ContentView as state router
+
+**Files:**
+- Modify: `Wanderback/Views/ContentView.swift`
+
+**Context:** ContentView devient le routeur principal. Il passe le ModelContext au ViewModel pour le geocoding. Il affiche: erreur, pas assez de photos, loading (LoadingView), ou pret (HomeView stub).
+
+- [ ] **Step 1: Refactor ContentView**
+
+```swift
+import SwiftUI
+import SwiftData
+
+struct ContentView: View {
+    @State private var viewModel = PhotoLibraryViewModel()
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        Group {
+            if let error = viewModel.errorMessage {
+                errorView(message: error)
+            } else if viewModel.notEnoughPhotos {
+                notEnoughPhotosView
+            } else if viewModel.isReady {
+                HomeView()
+            } else {
+                LoadingView(
+                    currentStep: viewModel.currentStep,
+                    gpsStatsText: viewModel.isLoading ? viewModel.gpsStatsText : ""
+                )
+            }
+        }
+        .task {
+            await viewModel.requestAccessAndLoadPhotos(modelContext: modelContext)
+        }
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 20) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 80))
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.system(size: 32))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 80)
+        }
+    }
+
+    private var notEnoughPhotosView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "map.circle")
+                .font(.system(size: 80))
+                .foregroundStyle(.orange)
+            Text("Pas assez de photos geolocalisees")
+                .font(.system(size: 38, weight: .semibold))
+            Text("Wanderback a besoin d'au moins \(PhotoIndexer.minimumDistinctLocations) lieux distincts pour fonctionner.")
+                .font(.system(size: 28))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 80)
+            Text(viewModel.gpsStatsText)
+                .font(.system(size: 24))
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .modelContainer(for: LocationCache.self)
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `xcodebuild -project Wanderback.xcodeproj -scheme Wanderback -destination 'platform=tvOS Simulator,name=Apple TV' build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Wanderback/Views/ContentView.swift
+git commit -m "feat: refactor ContentView as state router with LoadingView transition"
+```


### PR DESCRIPTION
## Résumé

Implémente les 6 écrans du handoff design « ludique game-show » (fond indigo, dégradés ambre→rose, immersion photo) en SwiftUI pour tvOS, en respectant les tokens, mesures et copies du README du handoff.

## Écrans

| Écran | Contenu |
|---|---|
| **LoadingView** | Globe pulsant (2,2 s), logo dégradé 76pt, barre de progression 900×12 branchée sur `IndexingStep` |
| **HomeView** | Mosaïque 5×2 des photos de l'utilisateur sous voile radial, tuiles mode Souvenir/Challenge, cercles de rounds 5/10/20, CTA « C'EST PARTI » (focus par défaut) |
| **GameView** | Photo du round plein écran, scrim, barre haute avec anneau chrono 68pt et score (Challenge), grille de 4 cartes réponse |
| **RevealView** | Zoom cinématique MapKit (~2,6 s Souvenir / 1,6 s Challenge), badge résultat, nom du lieu 104pt uppercase, vignettes du même jour, « +N pts » |
| **SummaryView** | Carte des lieux joués (pins ambre/rose alternés), score final 96pt dégradé, stats (bonnes réponses, km parcourus, pays visités), Rejouer / Changer de mode |
| **NotEnoughPlacesView** | Écran d'erreur avec conseil et **mode démo** (8 destinations fictives) |

## Architecture

- `DesignSystem/Theme.swift` : tokens du handoff (couleurs, dégradés, ombres, styles de boutons avec focus 180 ms via `@Environment(\.isFocused)`)
- `GameViewModel` étoffé : session, phases `playing/revealing/finished`, chrono 30 s, points dégressifs (1000 max, arrondis à la dizaine), stats de partie ; `RevealViewModel` supprimé
- `PhotoImageLoader` : chargement PhotoKit via `PHCachingImageManager`
- Navigation : Loading → Home → Game ⇄ Reveal → Summary, bouton Menu = retour accueil (`onExitCommand`)
- Args de dev (DEBUG) : `-demoMode`, `-screen game|reveal|summary|loading`

## Vérification

- Build Debug + Release OK (SDK tvOS 26.5, simulateur Apple TV 4K 1080p)
- Les 6 écrans capturés dans le simulateur et comparés aux maquettes du handoff (mode démo pour Home/Game/Reveal/Summary, bibliothèque vide pour l'écran d'erreur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)