### PR TITLE
Jeu possible dès 10 lieux identifiés, geocoding en arrière-plan

### DIFF
--- a/Wanderback/ViewModels/PhotoLibraryViewModel.swift
+++ b/Wanderback/ViewModels/PhotoLibraryViewModel.swift
@@ -67,6 +67,15 @@ class PhotoLibraryViewModel {
 
     var clusterCount: Int { clusters.count }
 
+    /// Clusters dont le nom de lieu est connu — les seuls utilisables pour une partie.
+    var geocodedClusters: [LocationCluster] {
+        clusters.filter { !$0.displayName.isEmpty }
+    }
+
+    /// Progression du geocoding qui continue derrière l'écran d'accueil.
+    /// Nil quand tout est identifié (ou pas encore commencé).
+    private(set) var backgroundGeocodingProgress: (done: Int, total: Int)?
+
     /// Bascule en mode démo avec des destinations fictives (écran « Pas assez de destinations »).
     func startDemoMode() {
         clusters = DemoData.clusters
@@ -160,11 +169,14 @@ class PhotoLibraryViewModel {
             return
         }
 
-        // Step 4: Geocoding — trier par taille (plus gros clusters d'abord)
+        // Step 4: Geocoding — trier par taille (plus gros clusters d'abord).
+        // Dès que `minimumGeocodedForPlay` lieux sont identifiés on passe en `.ready`
+        // (l'accueil s'affiche) et le reste continue en arrière-plan : la progression
+        // va alors dans `backgroundGeocodingProgress`, plus jamais dans `currentStep`.
         let sortedIndices = clusters.indices.sorted { clusters[$0].photoCount > clusters[$1].photoCount }
-        let minimumGeocodedForPlay = 20
+        let minimumGeocodedForPlay = 10
         let totalToGeocode = clusters.count
-        var geocodedCount = 0
+        var attemptedCount = 0
 
         currentStep = .geocoding(current: 0, total: totalToGeocode)
         logger.info("Step: geocoding \(totalToGeocode) clusters (play after \(minimumGeocodedForPlay))")
@@ -175,25 +187,34 @@ class PhotoLibraryViewModel {
                 clusters[i].displayName = cache.displayName
                 clusters[i].country = cache.country
             }
-            geocodedCount += 1
-            currentStep = .geocoding(current: geocodedCount, total: totalToGeocode)
+            attemptedCount += 1
 
-            // Dès qu'on a assez de clusters géocodés, passer en mode prêt
-            if geocodedCount == minimumGeocodedForPlay {
-                currentStep = .ready
-                logger.info("Step: ready — \(geocodedCount)/\(totalToGeocode) geocoded, \(self.countryCount) countries")
+            if isReady {
+                backgroundGeocodingProgress = (done: attemptedCount, total: totalToGeocode)
+            } else {
+                currentStep = .geocoding(current: attemptedCount, total: totalToGeocode)
+                // Assez de lieux identifiés (les échecs ne comptent pas) : on peut jouer
+                if geocodedClusters.count >= minimumGeocodedForPlay {
+                    currentStep = .ready
+                    backgroundGeocodingProgress = (done: attemptedCount, total: totalToGeocode)
+                    logger.info("Step: ready — \(attemptedCount)/\(totalToGeocode) geocoded, \(self.countryCount) countries")
+                }
             }
         }
 
-        // Fin du geocoding complet en arrière-plan
-        if geocodedCount > minimumGeocodedForPlay {
-            logger.info("Background geocoding complete: \(geocodedCount)/\(totalToGeocode)")
-        }
+        backgroundGeocodingProgress = nil
+        logger.info("Geocoding complete: \(self.geocodedClusters.count)/\(totalToGeocode) identified")
 
-        // Si moins de 20 clusters au total, on est prêt maintenant
+        // Moins de `minimumGeocodedForPlay` clusters au total : on est prêt maintenant
         if !isReady {
+            // Trop d'échecs de geocoding pour générer des questions (4 options minimum)
+            if geocodedClusters.count < ClusteringService.minimumClusters {
+                notEnoughPhotos = true
+                logger.warning("Not enough geocoded clusters: \(self.geocodedClusters.count)")
+                return
+            }
             currentStep = .ready
-            logger.info("Step: ready — \(geocodedCount) clusters geocoded, \(self.countryCount) countries")
+            logger.info("Step: ready — \(self.geocodedClusters.count) clusters geocoded, \(self.countryCount) countries")
         }
     }
 }

--- a/Wanderback/Views/ContentView.swift
+++ b/Wanderback/Views/ContentView.swift
@@ -29,10 +29,11 @@ struct ContentView: View {
             gameFlow
         } else if photoViewModel.isReady {
             HomeView(viewModel: photoViewModel) { mode, roundCount in
+                // Seuls les lieux déjà identifiés peuvent servir de question ou d'option
                 gameViewModel.startGame(
                     mode: mode,
                     roundCount: roundCount,
-                    clusters: photoViewModel.clusters
+                    clusters: photoViewModel.geocodedClusters
                 )
             }
         } else {
@@ -74,7 +75,7 @@ struct ContentView: View {
               photoViewModel.isReady else { return }
 
         let target = arguments[flagIndex + 1]
-        gameViewModel.startGame(mode: .challenge, roundCount: 3, clusters: photoViewModel.clusters)
+        gameViewModel.startGame(mode: .challenge, roundCount: 3, clusters: photoViewModel.geocodedClusters)
 
         switch target {
         case "reveal":

--- a/Wanderback/Views/HomeView.swift
+++ b/Wanderback/Views/HomeView.swift
@@ -164,13 +164,27 @@ struct HomeView: View {
     // MARK: - Stats
 
     private var statsRow: some View {
-        HStack(spacing: 52) {
-            Text("\(viewModel.photoLocations.count) photos GPS")
-            Text("\(viewModel.clusterCount) lieux")
-            Text("\(viewModel.countryCount) pays")
+        VStack(spacing: 10) {
+            HStack(spacing: 52) {
+                Text("\(viewModel.photoLocations.count) photos GPS")
+                Text("\(viewModel.geocodedClusters.count) lieux")
+                Text("\(viewModel.countryCount) pays")
+            }
+            .font(.system(size: 22))
+            .foregroundStyle(Theme.textTertiary)
+
+            // Le geocoding continue derrière l'accueil : le compteur de lieux grossit tout seul
+            if let progress = viewModel.backgroundGeocodingProgress {
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(Theme.textTertiary)
+                    Text("Identification des lieux en cours… \(progress.done)/\(progress.total)")
+                }
+                .font(.system(size: 19))
+                .foregroundStyle(Theme.textTertiary)
+            }
         }
-        .font(.system(size: 22))
-        .foregroundStyle(Theme.textTertiary)
     }
 
     // MARK: - CTA


### PR DESCRIPTION
## Résumé

Sur une grosse bibliothèque, le geocoding des ~500 clusters prend de longues minutes. Cette PR permet de lancer une partie dès que **10 lieux sont identifiés**, pendant que l'identification du reste continue derrière l'écran d'accueil.

## Bug corrigé au passage

Le code précédent était censé débloquer le jeu après 20 lieux, mais dès le lieu suivant la boucle réécrivait `currentStep = .geocoding(...)`, ce qui faisait retomber `isReady` à false et **renvoyait l'utilisateur sur l'écran de chargement** jusqu'à la fin complète du geocoding. C'est la cause de l'attente interminable constatée en test réel.

## Fonctionnement

- Le seuil de jeu passe à 10 lieux réellement identifiés (les échecs de geocoding ne comptent pas)
- Après le passage en `.ready`, la progression va dans `backgroundGeocodingProgress` — `currentStep` n'est plus jamais réécrit
- Les parties ne piochent que dans `geocodedClusters` (nom non vide) : ni la photo mystère ni les options de réponse ne peuvent venir d'un lieu inconnu
- L'accueil montre le nombre de lieux identifiés (il grossit en direct) et une ligne discrète « Identification des lieux en cours… N/total »
- Si moins de 4 lieux au total sont identifiables (minimum pour générer 4 options), l'écran « Pas assez de destinations » s'affiche

## Vérification

- Build Debug OK (SDK tvOS 27 bêta), zéro warning
- Accueil vérifié dans le simulateur en mode démo
- Le flux complet avec vraie bibliothèque est à valider sur Apple TV (le geocoding réel ne tourne pas dans le simulateur sans photos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)