### PR TITLE
Photos entières avec fond flouté, cartes réponse translucides, cartouche de révélation

### DIFF
--- a/Wanderback/DesignSystem/Theme.swift
+++ b/Wanderback/DesignSystem/Theme.swift
@@ -23,8 +23,9 @@ enum Theme {
     static let textSecondary = Color.white.opacity(0.7)
     static let textTertiary = Color.white.opacity(0.45)
 
-    /// Surface des cartes réponse
-    static let answerSurface = Color(red: 22 / 255, green: 20 / 255, blue: 42 / 255).opacity(0.78)
+    /// Surface des cartes réponse — volontairement très translucide pour laisser
+    /// transparaître la photo du round (le blur du matériau assure la lisibilité)
+    static let answerSurface = Color(red: 22 / 255, green: 20 / 255, blue: 42 / 255).opacity(0.4)
     static let answerBorder = Color.white.opacity(0.14)
 
     // MARK: - Dégradés

--- a/Wanderback/Views/GameView.swift
+++ b/Wanderback/Views/GameView.swift
@@ -30,12 +30,27 @@ struct GameView: View {
     @ViewBuilder
     private var photoBackground: some View {
         if let roundImage, loadedRoundId == gameViewModel.currentRound?.id {
+            // Photo entière (aspect fit) sur fond constitué de la même image
+            // zoomée et floutée — indispensable pour les photos portrait
             GeometryReader { geometry in
-                Image(uiImage: roundImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: geometry.size.width, height: geometry.size.height)
-                    .clipped()
+                ZStack {
+                    Image(uiImage: roundImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .clipped()
+                        .scaleEffect(1.2)
+                        .blur(radius: 45)
+                        .overlay(Color.black.opacity(0.3))
+
+                    Image(uiImage: roundImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .shadow(color: .black.opacity(0.5), radius: 40)
+                }
+                .frame(width: geometry.size.width, height: geometry.size.height)
+                .clipped()
             }
             .transition(.opacity)
         } else {

--- a/Wanderback/Views/RevealView.swift
+++ b/Wanderback/Views/RevealView.swift
@@ -98,11 +98,18 @@ struct RevealView: View {
     private func startCinematicZoom() {
         guard let coordinate = round?.correctAnswer.centerCoordinate else { return }
 
+        // Centre de caméra décalé au sud du lieu : le pin s'affiche dans le tiers
+        // haut de l'écran, bien séparé du cartouche titre/date
+        let offsetCenter = CLLocationCoordinate2D(
+            latitude: coordinate.latitude - 0.3,
+            longitude: coordinate.longitude
+        )
+
         // Zoom ~2–3 s en Souvenir, abrégé en Challenge
         let duration: TimeInterval = gameViewModel.mode == .challenge ? 1.6 : 2.6
         withAnimation(.easeInOut(duration: duration)) {
             cameraPosition = .camera(
-                MapCamera(centerCoordinate: coordinate, distance: 250_000, pitch: 0)
+                MapCamera(centerCoordinate: offsetCenter, distance: 250_000, pitch: 0)
             )
         }
         withAnimation(.easeOut(duration: 0.5).delay(duration * 0.4)) {
@@ -134,10 +141,8 @@ struct RevealView: View {
                 .font(.system(size: 104, weight: .heavy))
                 .tracking(4)
                 .foregroundStyle(.white)
-                .shadow(color: .black.opacity(0.6), radius: 30, y: 10)
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
-                .padding(.horizontal, 100)
 
             Text(round?.correctAnswer.country ?? "")
                 .font(.system(size: 32))
@@ -154,7 +159,21 @@ struct RevealView: View {
                     .padding(.top, 8)
             }
         }
-        .padding(.top, 260) // dégage le pin, qui reste au centre exact de la carte
+        .padding(.horizontal, 70)
+        .padding(.vertical, 40)
+        .background {
+            // Cartouche translucide : garde titre, lieu et date lisibles sur la carte
+            RoundedRectangle(cornerRadius: 28)
+                .fill(Color(red: 10 / 255, green: 9 / 255, blue: 20 / 255).opacity(0.55))
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28))
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 28)
+                .strokeBorder(Color.white.opacity(0.14), lineWidth: 2)
+        )
+        .shadow(color: Theme.tileShadow, radius: 30, y: 20)
+        .padding(.top, 280) // sous le pin, remonté dans le tiers haut de la carte
+        .padding(.horizontal, 100)
         .opacity(contentRevealed ? 1 : 0)
         .offset(y: contentRevealed ? 0 : 30)
     }


### PR DESCRIPTION
## Résumé

Trois ajustements UI issus des tests sur Apple TV :

1. **Cartes réponse plus translucides** — l'opacité de la surface passe de 0,78 à 0,4 : la photo du round reste visible derrière la grille de réponses, le blur `ultraThinMaterial` garantit la lisibilité (l'état focus — fond blanc — est inchangé)
2. **Photos affichées entières** — la photo du round est en aspect *fit* (plus jamais recadrée), posée sur un fond constitué de la même image zoomée (×1,2) et floutée (45pt) légèrement assombrie. Essentiel pour les photos portrait, neutre pour les photos paysage plein cadre
3. **RevealView plus lisible** — le pin du lieu est remonté dans le tiers haut de la carte (centre de caméra décalé de 0,3° au sud) et le bloc titre/pays/date/points est posé sur un cartouche translucide bordé, au lieu de flotter directement sur la carte

## Vérification

Captures simulateur (mode démo) : photo portrait synthétique vérifiée en fit + fond flouté, cartes réponse translucides sur le fond, révélation avec pin repositionné et cartouche. Build sans warning (SDK tvOS 27 bêta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)