### PR TITLE
Corrige le focus bloqué sur « Changer de mode » (SummaryView)

### DIFF
--- a/Wanderback.xcodeproj/project.pbxproj
+++ b/Wanderback.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2630;
-				LastUpgradeCheck = 2630;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					3F0A46702F65D3A100A3FD2D = {
 						CreatedOnToolsVersion = 26.3;
@@ -183,6 +183,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = appletvos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TVOS_DEPLOYMENT_TARGET = 26.2;
@@ -240,6 +241,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = appletvos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				TVOS_DEPLOYMENT_TARGET = 26.2;
 				VALIDATE_PRODUCT = YES;

--- a/Wanderback/Views/RevealView.swift
+++ b/Wanderback/Views/RevealView.swift
@@ -65,6 +65,8 @@ struct RevealView: View {
             }
         }
         .mapStyle(.standard(elevation: .realistic, pointsOfInterest: .excludingAll))
+        // Empêche la carte plein écran de capter le focus tvOS (cf. SummaryView)
+        .disabled(true)
     }
 
     /// Pin 28pt : cercle erreur + halo à 30 %.

--- a/Wanderback/Views/SummaryView.swift
+++ b/Wanderback/Views/SummaryView.swift
@@ -50,6 +50,7 @@ struct SummaryView: View {
                     }
                     .buttonStyle(SecondaryPillButtonStyle())
                 }
+                .focusSection()
             }
             .padding(.bottom, 70)
         }
@@ -68,6 +69,9 @@ struct SummaryView: View {
             }
         }
         .mapStyle(.standard(pointsOfInterest: .excludingAll))
+        // Sans ça, la carte plein écran capte le focus tvOS et empêche
+        // de naviguer de « Rejouer » vers « Changer de mode »
+        .disabled(true)
     }
 
     /// Pin ambre/rose alterné avec halo à 25 %.


### PR DESCRIPTION
## Résumé

Sur l'Apple TV réelle, impossible de déplacer le focus de « Rejouer » vers « Changer de mode » à la fin d'une partie.

**Cause** : sur tvOS, la carte MapKit plein écran est focusable par défaut. Comme son cadre englobe géométriquement les boutons, elle capte les déplacements du focus et « Changer de mode » devient inatteignable.

**Correctif** :
- `.disabled(true)` sur les cartes de `SummaryView` et `RevealView` (elles n'ont de toute façon aucune interaction : `interactionModes: []`)
- `.focusSection()` sur la rangée de boutons du récap

Note : ce commit avait été poussé sur la branche de la PR #32 quelques minutes après son merge — cette PR le reprend proprement sur main.

## Vérification

- Build OK, visuel du récap inchangé en simulateur (la carte se rend normalement malgré `disabled`)
- La navigation télécommande est à valider sur l'Apple TV — c'est le point qui ne se teste pas en headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)