### PR TITLE
Affiche la ville seule comme nom de lieu

### DIFF
--- a/Wanderback/Persistence/LocationCache.swift
+++ b/Wanderback/Persistence/LocationCache.swift
@@ -26,8 +26,11 @@ class LocationCache {
         CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
     }
 
+    /// Ville seule — le pays est affiché séparément dans toute l'UI
+    /// (concaténer ville, région et pays donnait « Rouen, Normandie, France »
+    /// sur les cartes réponse, avec le pays répété en dessous)
     var displayName: String {
-        [city, region, country].compactMap { $0 }.joined(separator: ", ")
+        city ?? region ?? country
     }
 
     func distance(to coordinate: CLLocationCoordinate2D) -> CLLocationDistance {


### PR DESCRIPTION
## Résumé

Constaté dans les logs des tests sur Apple TV : `LocationCache.displayName` concatène ville, région et pays, ce qui donne sur les cartes réponse « Rouen, Normandie, France » en gros caractères avec « France » répété en dessous — et des cas dégénérés comme « Province de la Ville de La Havane, Province de la Ville de La Havane, Cuba ».

`displayName` devient la ville seule, avec repli sur la région puis le pays quand la ville est inconnue du geocoder. Le pays reste affiché séparément (sous-titre des cartes réponse, ligne pays de la révélation) — aucune information perdue.

Les données en cache SwiftData ne sont pas migrées : ville, région et pays y sont stockés en champs séparés, seule la propriété calculée change.

## Vérification

Build OK (SDK tvOS 27 bêta). Rendu à confirmer sur Apple TV avec la vraie bibliothèque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)