### PR TITLE
Précharge MapKit pendant le round et exclut les lieux « Unknown »

### DIFF
--- a/Wanderback/Persistence/LocationCache.swift
+++ b/Wanderback/Persistence/LocationCache.swift
@@ -33,6 +33,13 @@ class LocationCache {
         city ?? region ?? country
     }
 
+    /// Vrai si le geocoding a produit un nom exploitable pour le jeu :
+    /// une ville ou une région, et un pays identifié. Les lieux « Unknown »
+    /// ne doivent servir ni de question ni d'option de réponse.
+    var hasUsableName: Bool {
+        (city != nil || region != nil) && country != "Unknown"
+    }
+
     func distance(to coordinate: CLLocationCoordinate2D) -> CLLocationDistance {
         let cached = CLLocation(latitude: latitude, longitude: longitude)
         let target = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)

--- a/Wanderback/Services/MapPrefetcher.swift
+++ b/Wanderback/Services/MapPrefetcher.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MapKit
+
+/// Préchauffe MapKit pendant que le joueur regarde la photo du round :
+/// la première création d'une carte dans le process (shaders Metal,
+/// ressources GeoCodec) et le téléchargement des tuiles de la région
+/// révélée se font en avance, au lieu de provoquer un écran vide à
+/// l'apparition de RevealView.
+@MainActor
+final class MapPrefetcher {
+    static let shared = MapPrefetcher()
+
+    private var currentTask: Task<Void, Never>?
+
+    private init() {}
+
+    /// Lance en tâche de fond un snapshot de la région du lieu à révéler.
+    /// Le résultat est jeté — seul l'effet de cache compte.
+    func prefetch(for cluster: LocationCluster) {
+        currentTask?.cancel()
+        currentTask = Task {
+            let configuration = MKStandardMapConfiguration(elevationStyle: .realistic)
+            configuration.pointOfInterestFilter = .excludingAll
+
+            let options = MKMapSnapshotter.Options()
+            options.region = MKCoordinateRegion(
+                center: cluster.centerCoordinate,
+                latitudinalMeters: 300_000,
+                longitudinalMeters: 300_000
+            )
+            options.size = CGSize(width: 480, height: 270)
+            options.preferredConfiguration = configuration
+
+            _ = try? await MKMapSnapshotter(options: options).start()
+        }
+    }
+}

--- a/Wanderback/ViewModels/PhotoLibraryViewModel.swift
+++ b/Wanderback/ViewModels/PhotoLibraryViewModel.swift
@@ -183,7 +183,10 @@ class PhotoLibraryViewModel {
 
         for i in sortedIndices {
             let coord = clusters[i].centerCoordinate
-            if let cache = await geocoderService.reverseGeocode(coordinate: coord, modelContext: modelContext) {
+            // Un lieu sans nom exploitable (« Unknown ») reste displayName vide :
+            // il est exclu de geocodedClusters, donc jamais joué
+            if let cache = await geocoderService.reverseGeocode(coordinate: coord, modelContext: modelContext),
+               cache.hasUsableName {
                 clusters[i].displayName = cache.displayName
                 clusters[i].country = cache.country
             }

--- a/Wanderback/Views/GameView.swift
+++ b/Wanderback/Views/GameView.swift
@@ -155,6 +155,8 @@ struct GameView: View {
 
     private func loadRoundPhoto() async {
         guard let round = gameViewModel.currentRound else { return }
+        // Préchauffe MapKit et les tuiles du lieu pendant que le joueur réfléchit
+        MapPrefetcher.shared.prefetch(for: round.correctAnswer)
         roundImage = nil
         let image = await PhotoImageLoader.shared.loadImage(
             assetIdentifier: round.photo.assetIdentifier,

--- a/Wanderback/Views/RevealView.swift
+++ b/Wanderback/Views/RevealView.swift
@@ -26,6 +26,8 @@ struct RevealView: View {
 
     var body: some View {
         ZStack {
+            // Sous la carte : évite un écran vide pendant l'initialisation MapKit
+            SceneBackground()
             map
             vignette
 

--- a/Wanderback/Views/SummaryView.swift
+++ b/Wanderback/Views/SummaryView.swift
@@ -12,6 +12,8 @@ struct SummaryView: View {
 
     var body: some View {
         ZStack {
+            // Sous la carte : évite un écran vide pendant l'initialisation MapKit
+            SceneBackground()
             worldMap
             mapVeil
 


### PR DESCRIPTION
## Résumé

Deux retours des tests sur Apple TV réelle.

### 1. Écran vide avant la première révélation

À la première réponse, MapKit s'initialise entièrement (shaders Metal, ressources GeoCodec — visibles dans les logs : `default.csv`, `CAMetalLayer`) et télécharge les tuiles au moment même où `RevealView` apparaît, d'où un moment d'affichage vide.

- Nouveau `MapPrefetcher` : dès l'affichage de la photo d'un round, un `MKMapSnapshotter` discret (480×270, résultat jeté) est lancé sur la région de la bonne réponse — l'initialisation du framework et le cache de tuiles se font pendant que le joueur réfléchit
- `SceneBackground` ajouté sous les cartes de `RevealView` et `SummaryView` : toute latence résiduelle affiche le fond indigo du thème au lieu d'un écran vide

### 2. Options de réponse « Unknown »

Les lieux dont le geocoding ne produit ni ville ni région, ou un pays inconnu (`country == "Unknown"`), sont désormais exclus du jeu : leur `displayName` reste vide, ils sortent de `geocodedClusters` et ne peuvent plus être ni la question ni une option. Le seuil « jouable à 10 lieux » ne compte que des lieux exploitables. Les entrées « Unknown » déjà en cache SwiftData sont filtrées de la même façon à la relecture — pas de migration nécessaire.

## Vérification

Build OK (SDK tvOS 27 bêta), zéro warning. L'effet du préchargement est à mesurer sur l'Apple TV au premier lancement après redémarrage de l'app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)